### PR TITLE
[MH-18184] Remove oauth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           docker ps | grep ${{ steps.meta.outputs.tags }} | cut -d" " -f1 | xargs docker rm -f
 
       - name: Archive Mayhem for API report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: reports
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
         uses: actions/setup-java@v3

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -52,10 +52,6 @@ paths:
                 $ref: '#/components/schemas/Pet'
         '400':
           description: Invalid input
-      security:
-        - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -91,10 +87,6 @@ paths:
           description: Pet not found
         '405':
           description: Validation exception
-      security:
-        - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -144,10 +136,6 @@ paths:
                   $ref: '#/components/schemas/Pet'
         '400':
           description: Invalid status value
-      security:
-        - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
   /pet/findByTags:
     get:
       tags:
@@ -183,10 +171,6 @@ paths:
                   $ref: '#/components/schemas/Pet'
         '400':
           description: Invalid tag value
-      security:
-        - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
   '/pet/{petId}':
     get:
       tags:
@@ -216,11 +200,6 @@ paths:
           description: Invalid ID supplied
         '404':
           description: Pet not found
-      security:
-        - api_key: []
-        - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
     post:
       tags:
         - pet
@@ -248,10 +227,6 @@ paths:
       responses:
         '405':
           description: Invalid input
-      security:
-        - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
     delete:
       tags:
         - pet
@@ -275,10 +250,6 @@ paths:
       responses:
         '400':
           description: Invalid pet value
-      security:
-        - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
   '/pet/{petId}/uploadImage':
     post:
       tags:
@@ -307,10 +278,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiResponse'
-      security:
-        - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
       requestBody:
         content:
           application/octet-stream:
@@ -335,8 +302,6 @@ paths:
                 additionalProperties:
                   type: integer
                   format: int32
-      security:
-        - api_key: []
   /store/order:
     post:
       tags:
@@ -804,16 +769,3 @@ components:
             items:
               $ref: '#/components/schemas/User'
       description: List of user object
-  securitySchemes:
-    petstore_auth:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
-          scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
-    api_key:
-      type: apiKey
-      name: api_key
-      in: header


### PR DESCRIPTION
[MH-18184](https://forallsecure.atlassian.net/browse/MH-18184)
Problem: since we added oauth support in MAPI, running mapi on demo fails with error: `An unexpected error occurred - Specification error: OAuth2 flows have been specified but no Client ID and Client Secret has been provided`

Notes:
1. The demo endpoints work without auth
2. The OpenAPI spec doesn't seem auto-generated